### PR TITLE
修改ZStack 中英文名称

### DIFF
--- a/docs/communities-list.md
+++ b/docs/communities-list.md
@@ -22,7 +22,7 @@
 | 014  | OI Wiki                 | OI Wiki                 | [link](https://oi-wiki.org)                            | 审核通过 |
 | 015  | openLooKeng             | openLooKeng             | [link](https://openlookeng.io/)                        | 审核通过 |
 | 016  | openGauss               | openGauss               | [link](https://opengauss.org)                          | 审核通过 |
-| 017  | ZStack                  | ZStack                  | [link](https://www.zstack.io/)                         | 审核通过 |
+| 017  | ZStack Cloud            | ZStack Cloud 平台       | [link](https://www.zstack.io/)                         | 审核通过 |
 | ...  | ...                     | ...                     | ...                                                    | ...      |
 
 注：已报名的社区可能由于还处在组委会还在审核或者社区信息还在补充等原因而还未进行审核，一般情况下在每周一组委会例会后更新一次。


### PR DESCRIPTION
中文的社区名称改为 ZStack Cloud 平台
英文的社区名称改为 ZStack Cloud